### PR TITLE
include current events in events view

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -16,5 +16,5 @@ class IndexView(TemplateView):
         four_weeks_from_now = now + timedelta(weeks=4)
 
         context['events'] = Event.objects.filter(
-            published=True, start__gte=now, start__lte=four_weeks_from_now)
+            published=True, end__gte=now, start__lte=four_weeks_from_now)
         return context


### PR DESCRIPTION
Change the query for events to show events that have already started
in the "upcoming events" list. This ensures that on the day of an
event, the event details are easily found while the event is still
ongoing.